### PR TITLE
When the event starts

### DIFF
--- a/2/info/index.html
+++ b/2/info/index.html
@@ -61,6 +61,8 @@
         <h2>March 23, 2024 @ 12:00 AM EST - March 23, 2024 @ 3:00 PM EST</h2>
         <p>What's happening?</p>
         <h2>Minecraft build battle</h3>
+        <h1>Event Started!</h1>
+        <p>Join at wolsocial.minehut.gg</p>
         <div class="squircle">
             <a href="https://wheeloflifemc.github.io/social/2/addtogcal/" target="_blank"><img src="https://ssl.gstatic.com/calendar/images/dynamiclogo_2020q4/calendar_31_2x.png"alt="Add toGoogle Calendar"></a>
         </div>


### PR DESCRIPTION
This is a a bad idea since anybody can see pull request info and join early, except most of our players don't even know what github is (from the twitter poll data) so its fine for now